### PR TITLE
fix: :bug: try relative symlink for collections

### DIFF
--- a/molecule/shared/collections/ansible_collections/depin
+++ b/molecule/shared/collections/ansible_collections/depin
@@ -1,1 +1,1 @@
-/Users/anthonyra/Documents/DeEEP/bedrock/depin
+../../../../depin


### PR DESCRIPTION
### TL;DR

Updated the symlink for the depin collection to use a relative path.

### What changed?

The symlink for the depin collection in `molecule/shared/collections/ansible_collections/depin` has been modified to use a relative path (`../../../../depin`) instead of an absolute path (`/Users/anthonyra/Documents/DeEEP/bedrock/depin`).

### How to test?

1. Navigate to the `molecule/shared/collections/ansible_collections/` directory.
2. Verify that the `depin` symlink points to the correct relative path:
   ```
   ls -l depin
   ```
   The output should show: `depin -> ../../../../depin`

### Why make this change?

Using a relative path for the symlink improves portability and ensures the collection can be accessed correctly across different environments and user setups. This change eliminates dependencies on specific user directories and makes the project structure more flexible and easier to maintain.