### PR TITLE
docs: :memo: updated service issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-new-service.yml
+++ b/.github/ISSUE_TEMPLATE/1-new-service.yml
@@ -76,6 +76,8 @@ body:
             - status
             - reset / restart counter
 
+        - [ ] assigned metrics port to collector -- [here](https://github.com/deeep-network/bedrock/blob/4f423edd99283be38b6f3f63625086a29009487d/depin/core/roles/metrics/defaults/main.yml#L6)
+
         ### Logs
 
         - [ ] logs are collected via journald


### PR DESCRIPTION
### TL;DR

Added a new checklist item for assigning metrics port to collector in the new service issue template.

### What changed?

Updated the `.github/ISSUE_TEMPLATE/1-new-service.yml` file by adding a new checklist item under the metrics section. The new item prompts users to assign a metrics port to the collector and includes a link to the relevant configuration file.

### How to test?

1. Create a new issue using the "New Service" template.
2. Verify that the new checklist item "assigned metrics port to collector" is present under the metrics section.
3. Confirm that the link in the checklist item directs to the correct file and location.

### Why make this change?

This addition ensures that developers remember to assign a metrics port to the collector when setting up a new service. It helps maintain consistency in metrics collection across services and prevents potential oversights in the setup process.