### PR TITLE
fix: :bug: fixes integration issues with coral reef

### DIFF
--- a/deeep/core/galaxy.yml
+++ b/deeep/core/galaxy.yml
@@ -14,6 +14,7 @@ tags: []
 dependencies:
   ansible.posix: "1.5.4"
   ansible.eda: "2.2.0"
+  community.general: "10.2.0"
 
 repository: https://github.com/deeep-network/ansible_collections
 documentation: https://docs.deeep.network

--- a/deeep/core/playbooks/eda_services.yml
+++ b/deeep/core/playbooks/eda_services.yml
@@ -9,6 +9,10 @@
     hab_sup_api_url: http://localhost:9631/services
     services_api_url: https://beta.deeep.network/api/v1/vm/{{ ansible_nodename }}/services
   tasks:
+    - name: Ensure running on VM
+      ansible.builtin.assert:
+        that: ansible_virtualization_role == 'guest'
+
     - name: Fetch required services from API
       ansible.builtin.uri:
         url: "{{ services_api_url }}"

--- a/deeep/core/playbooks/eda_vms.yml
+++ b/deeep/core/playbooks/eda_vms.yml
@@ -8,6 +8,10 @@
     min_available_memory_mb: 4096
     min_available_disk_gb: 120
   tasks:
+    - name: Ensure running on VM
+      ansible.builtin.assert:
+        that: ansible_virtualization_role == 'host'
+
     - name: Check disk space
       when: ansible_mounts is defined
       block:
@@ -91,8 +95,8 @@
 
     - name: Deploy VM
       when:
-        - ansible_virtualization_role == 'host'
         - _claim['json']['vm'] is defined
+        - _claim['json']['vm'] is not none
       block:
         - name: Create VM with LXD
           vars:
@@ -135,6 +139,9 @@
           no_log: true
           block:
             - name: Fetch private key from Pulumi
+              become: true
+              become_user: nerdnode
+              become_flags: "-i"
               ansible.builtin.command:
                 cmd: esc env open deeep-network/prod/deeep-device 'device.private_key'
               changed_when: false
@@ -143,7 +150,7 @@
             - name: Save private key file
               become: true
               ansible.builtin.command:
-                cmd: lxc exec {{ claim_results['json']['vm'] }} -- su -c "echo {{ private_key.stdout }} | base64 -d > /device-private-key"
+                cmd: sudo lxc exec {{ claim_results['json']['vm'] }} -- su -c "echo {{ private_key.stdout }} | base64 -d > /device-private-key"
               changed_when: false
 
     - name: Check for orphaned VM
@@ -155,7 +162,6 @@
 
     - name: Destroy VM
       when:
-        - ansible_virtualization_role == 'host'
         - _orphaned['json']['vms'] | length > 0
       block:
         - name: Delete a container

--- a/deeep/core/playbooks/templates/auto-deploy.service.j2
+++ b/deeep/core/playbooks/templates/auto-deploy.service.j2
@@ -5,9 +5,9 @@ After=network.target
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/curl \
-  -H 'Content-Type: application/json' \
-  -d '{"trigger": "{{ eda_rulebook | default('eda_vms') }}"}' \
-  127.0.0.1:33337/endpoint
+  -sH "Content-Type: application/json" \
+  -d '{"trigger":"{{ eda_rulebook | default("eda_vms")}}"}' \
+  http://127.0.0.1:33337/endpoint
 
 [Install]
 WantedBy=multi-user.target

--- a/deeep/core/playbooks/templates/auto-deploy.timer.j2
+++ b/deeep/core/playbooks/templates/auto-deploy.timer.j2
@@ -6,7 +6,6 @@ BindsTo=hab-supervisor.service
 [Timer]
 Unit=auto-deploy.service
 OnUnitInactiveSec=10min
-OnBootSec=10min
 RandomizedDelaySec=5min
 FixedRandomDelay=true
 

--- a/deeep/core/playbooks/templates/user-data.yml.j2
+++ b/deeep/core/playbooks/templates/user-data.yml.j2
@@ -60,6 +60,6 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable hab-supervisor.service auto-deploy.timer
   - systemctl start hab-supervisor.service auto-deploy.timer
-  - hab pkg install deeep-network/step
-  - hab svc load deeep-network/ilert-heartbeat --strategy at-once
-  - hab svc load deeep-network/ansible --strategy at-once
+  - su - nerdnode -c 'hab pkg install deeep-network/step'
+  - su - nerdnode -c 'hab svc load deeep-network/ilert-heartbeat --strategy at-once'
+  - su - nerdnode -c 'hab svc load deeep-network/ansible --strategy at-once'

--- a/deeep/core/roles/service/tasks/commands/install.yml
+++ b/deeep/core/roles/service/tasks/commands/install.yml
@@ -1,5 +1,5 @@
 - name: Install {{ service_name }}
   become: true
-  ansible.builtin.command: 
-    cmd: hab pkg install deeep-network/{{ service_name }}
+  ansible.builtin.command:
+    cmd: sudo hab pkg install deeep-network/{{ service_name }}
   changed_when: false

--- a/deeep/core/roles/service/tasks/commands/start.yml
+++ b/deeep/core/roles/service/tasks/commands/start.yml
@@ -1,7 +1,7 @@
 ---
 - name: Start {{ service_name }}
   become: true
-  ansible.builtin.command: 
-    cmd: hab svc load deeep-network/{{ service_name }} --group services --strategy rolling --topology leader
+  ansible.builtin.command:
+    cmd: sudo hab svc load deeep-network/{{ service_name }} --group services --strategy rolling --topology leader
     creates: /hab/svc/{{ service_name }}
   changed_when: false

--- a/deeep/core/roles/service/tasks/commands/stop.yml
+++ b/deeep/core/roles/service/tasks/commands/stop.yml
@@ -1,7 +1,7 @@
 ---
 - name: Stop {{ service_name }}
   become: true
-  ansible.builtin.command: 
-    cmd: hab svc unload deeep-network/{{ service_name }}
+  ansible.builtin.command:
+    cmd: sudo hab svc unload deeep-network/{{ service_name }}
     removes: /hab/svc/{{ service_name }}
   changed_when: false

--- a/deeep/core/roles/service/tasks/commands/uninstall.yml
+++ b/deeep/core/roles/service/tasks/commands/uninstall.yml
@@ -4,6 +4,6 @@
 
 - name: Uninstall {{ service_name }}
   become: true
-  ansible.builtin.command: 
-    cmd: hab pkg uninstall deeep-network/{{ service_name }}
+  ansible.builtin.command:
+    cmd: sudo hab pkg uninstall deeep-network/{{ service_name }}
   changed_when: false


### PR DESCRIPTION
### TL;DR

Added virtualization role checks and fixed permission issues in VM and service management.

### What changed?

- Added virtualization role assertions to ensure playbooks run on correct host types
- Fixed permission issues by adding proper sudo commands and user context
- Added community.general dependency
- Improved systemd service/timer configurations
- Modified hab commands to run under correct user context
- Updated VM deployment logic to handle null VM cases
- Adjusted private key handling with proper user permissions

### How to test?

1. Run the eda_vms playbook on a host system to verify VM deployment
2. Run the eda_services playbook inside a VM to verify service management
3. Verify hab commands execute under the nerdnode user
4. Check that auto-deploy timer triggers correctly
5. Verify service installation and management works with proper permissions

### Why make this change?

To prevent playbooks from running on incorrect host types and resolve permission-related issues that were causing service deployment failures. This ensures more reliable VM and service management while maintaining proper security contexts.