### PR TITLE
fix: :bug: fixes bootstrapping VMs

### DIFF
--- a/deeep/core/playbooks/eda_vms.yml
+++ b/deeep/core/playbooks/eda_vms.yml
@@ -97,15 +97,15 @@
       when:
         - _claim['json']['vm'] is defined
         - _claim['json']['vm'] is not none
+      vars:
+        vm: "{{ _claim['json']['vm'] }}"
+        vm_hostname: "{{ vm['name'] | split('.') | first }}.box.nerd-node.com"
+        eda_rulebook: "eda_services"
+        _vcpus: "{{ vm['vcpus'] | int }}"
+        _memory: "{{ (vm['memory'] | int >= 1024) | ternary(vm['memory'] | int, '1024') }}MiB"
+        _disk: "{{ vm['disk'] | int }}GiB"
       block:
         - name: Create VM with LXD
-          vars:
-            vm: "{{ _claim['json']['vm'] }}"
-            vm_hostname: "{{ vm['name'] | split('.') | first }}.box.nerd-node.com"
-            eda_rulebook: "eda_services"
-            _vcpus: "{{ vm['vcpus'] | int }}"
-            _memory: "{{ (vm['memory'] | int >= 1024) | ternary(vm['memory'] | int, '1024') }}MiB"
-            _disk: "{{ vm['disk'] | int }}GiB"
           community.general.lxd_container:
             name: "{{ vm['name'] }}"
             ignore_volatile_options: true
@@ -142,15 +142,16 @@
               become: true
               become_user: nerdnode
               become_flags: "-i"
+              # @todo should be moved to a chef habitat package to be installed in /usr/local/bin
               ansible.builtin.command:
-                cmd: esc env open deeep-network/prod/deeep-device 'device.private_key'
+                cmd: $HOME/.pulumi/bin/esc env open deeep-network/prod/deeep-device 'device.private_key'
               changed_when: false
               register: private_key
 
             - name: Save private key file
               become: true
               ansible.builtin.command:
-                cmd: sudo lxc exec {{ claim_results['json']['vm'] }} -- su -c "echo {{ private_key.stdout }} | base64 -d > /device-private-key"
+                cmd: sudo lxc exec {{ vm['name'] }} -- su -c "echo {{ private_key.stdout }} | base64 -d > /device-private-key"
               changed_when: false
 
     - name: Check for orphaned VM

--- a/deeep/core/playbooks/files/bootstrap.sh
+++ b/deeep/core/playbooks/files/bootstrap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if ! hab svc status | grep -q "ilert-heartbeat"; then
+  echo "Loading ilert-heartbeat service..."
+  hab svc load deeep-network/ilert-heartbeat
+fi
+
+if ! hab svc status | grep -q "ansible"; then
+  echo "Installing step package..."
+  hab pkg install deeep-network/step
+
+  echo "Loading ansible service..."
+  hab svc load deeep-network/ansible
+fi

--- a/deeep/core/playbooks/templates/auto-deploy.service.j2
+++ b/deeep/core/playbooks/templates/auto-deploy.service.j2
@@ -1,9 +1,11 @@
 [Unit]
 Description=Auto-Deploy Trigger
+Requires=hab-supervisor.service
 After=network.target
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/bash /run/bootstrap.sh
 ExecStart=/usr/bin/curl \
   -sH "Content-Type: application/json" \
   -d '{"trigger":"{{ eda_rulebook | default("eda_vms")}}"}' \

--- a/deeep/core/playbooks/templates/user-data.yml.j2
+++ b/deeep/core/playbooks/templates/user-data.yml.j2
@@ -45,13 +45,16 @@ write_files:
       HAB_AUTH_TOKEN={{ ansible_env['HAB_AUTH_TOKEN'] | default(lookup('env', 'HAB_AUTH_TOKEN')) }}
   - path: /etc/systemd/system/hab-supervisor.service
     content: |
-      {{ lookup('ansible.builtin.template', 'hab-supervisor.service.j2') | trim | indent( width=8 )}}
+      {{ lookup('ansible.builtin.template', 'hab-supervisor.service.j2') | trim | indent( width=6 ) }}
+  - path: /run/bootstrap.sh
+    content: |
+      {{ lookup('ansible.builtin.file', 'bootstrap.sh') | trim | indent( width=6 ) }}
   - path: /etc/systemd/system/auto-deploy.service
     content: |
-      {{ lookup('ansible.builtin.template', 'auto-deploy.service.j2') | trim | indent( width=8 ) }}
+      {{ lookup('ansible.builtin.template', 'auto-deploy.service.j2') | trim | indent( width=6 ) }}
   - path: /etc/systemd/system/auto-deploy.timer
     content: |
-      {{ lookup('ansible.builtin.template', 'auto-deploy.timer.j2') | trim | indent( width=8 ) }}
+      {{ lookup('ansible.builtin.template', 'auto-deploy.timer.j2') | trim | indent( width=6 ) }}
 
 runcmd:
   - curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | bash
@@ -60,6 +63,4 @@ runcmd:
   - systemctl daemon-reload
   - systemctl enable hab-supervisor.service auto-deploy.timer
   - systemctl start hab-supervisor.service auto-deploy.timer
-  - su - nerdnode -c 'hab pkg install deeep-network/step'
-  - su - nerdnode -c 'hab svc load deeep-network/ilert-heartbeat --strategy at-once'
-  - su - nerdnode -c 'hab svc load deeep-network/ansible --strategy at-once'
+


### PR DESCRIPTION
### TL;DR
Improved VM provisioning process and service initialization in the EDA playbooks

### What changed?
- Moved VM variables outside of the create VM block for better reusability
- Fixed private key command to use the full path to `esc` binary
- Added a new `bootstrap.sh` script to handle service initialization
- Updated systemd service dependencies and execution order
- Adjusted template indentation for consistent formatting
- Moved habitat package installation and service loading to the bootstrap script

### How to test?
1. Create a new VM using the EDA playbook
2. Verify that the VM provisions correctly with the proper hostname
3. Confirm that habitat services (ilert-heartbeat and ansible) are loaded automatically
4. Check that the auto-deploy service starts after the habitat supervisor
5. Validate that the private key is correctly saved in the VM

### Why make this change?
To improve the reliability and maintainability of the VM provisioning process by:
- Ensuring consistent service initialization
- Making the habitat service loading process more robust
- Providing better organization of configuration variables
- Establishing proper service dependencies in systemd