### PR TITLE
fix: :bug: auto-deploy service tweaks

### DIFF
--- a/deeep/core/galaxy.yml
+++ b/deeep/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: deeep
 name: core
-version: 3.0.0
+version: 1.0.3
 readme: README.md
 authors:
 - Anthony Anderson anthony@deeep.network

--- a/deeep/core/playbooks/templates/auto-deploy.service.j2
+++ b/deeep/core/playbooks/templates/auto-deploy.service.j2
@@ -1,6 +1,9 @@
 [Unit]
 Description=Auto-Deploy Trigger
 Requires=hab-supervisor.service
+# can only be called by auto-deploy.timer
+RefuseManualStart=true
+RefuseManualStop=true
 After=network.target
 
 [Service]

--- a/deeep/core/playbooks/templates/auto-deploy.timer.j2
+++ b/deeep/core/playbooks/templates/auto-deploy.timer.j2
@@ -5,6 +5,7 @@ BindsTo=hab-supervisor.service
 
 [Timer]
 Unit=auto-deploy.service
+OnActiveSec=30s
 OnUnitInactiveSec=10min
 RandomizedDelaySec=5min
 FixedRandomDelay=true


### PR DESCRIPTION
### TL;DR
Updated auto-deploy systemd service configuration and adjusted collection version

### What changed?
- Downgraded collection version from 3.0.0 to 1.0.3
- Added `RefuseManualStart` and `RefuseManualStop` flags to auto-deploy service
- Introduced `OnActiveSec=30s` timer setting for initial deployment trigger

### How to test?
1. Install the updated collection version
2. Verify that auto-deploy service cannot be manually started/stopped
3. Confirm auto-deploy triggers initially after 30 seconds
4. Validate subsequent deployments occur every 10 minutes (+/- 5 min random delay)

### Why make this change?
- Prevents manual interference with the auto-deploy service
- Ensures initial deployment occurs shortly after system startup
- Maintains proper versioning for the collection
- Preserves existing randomized deployment schedule for subsequent runs