### PR TITLE
fix: :bug: typos and other issues

### DIFF
--- a/deeep/core/galaxy.yml
+++ b/deeep/core/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: deeep
 name: core
-version: 2.1.0
+version: 2.1.2
 readme: README.md
 authors:
 - Anthony Anderson anthony@deeep.network

--- a/deeep/core/playbooks/setup.yml
+++ b/deeep/core/playbooks/setup.yml
@@ -14,21 +14,28 @@
       ansible.builtin.command: sudo hab pkg install deeep-network/grafana-alloy
       changed_when: false
 
-    - name: Set auto-deploy systemd files
+    - name: Create systemd service files
       ansible.builtin.template:
         src: "{{ item }}.j2"
         dest: /etc/systemd/system/{{ item }}
         mode: '0644'
       loop:
+        - hab-supervisor.service
         - auto-deploy.service
         - auto-deploy.timer
 
-    - name: Enable and start auto-deploy timer
+    - name: Reload systemctl daemon
       ansible.builtin.systemd:
-        name: auto-deploy.timer
+        daemon_reload: true
+
+    - name: Enable and start services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
         state: started
         enabled: true
-        daemon_reload: true
+      loop:
+        - hab-supervisor.service
+        - auto-deploy.timer
 
     - name: Install Heartbeat
       ansible.builtin.command: sudo hab svc load deeep-network/ilert-heartbeat

--- a/deeep/core/playbooks/templates/hab-supervisor.service.j2
+++ b/deeep/core/playbooks/templates/hab-supervisor.service.j2
@@ -5,7 +5,7 @@ Description=The Chef Habitat Supervisor
 EnvironmentFile=/etc/environment
 ExecStart=/usr/bin/hab sup run \
   --keep-latest-packages 2 \
-{%- if deeep_playbook is defined and deeep_playbook == 'manage_services' %}
+{%- if ansible_virtualization_role == 'guest' %}
   --strategy at-once \
   --peer hab-bastion-1.lxd \
   --peer hab-bastion-2.lxd \

--- a/deeep/core/roles/manage_vms/tasks/check_capacity.yml
+++ b/deeep/core/roles/manage_vms/tasks/check_capacity.yml
@@ -16,7 +16,7 @@
       {{ (ansible_memtotal_mb / 1024 - manage_vms_host_os_ram_gb - (ansible_memtotal_mb / 1024 * manage_vms_host_ram_buffer_percent / 100)) }}
   ansible.builtin.set_fact:
     max_vms_cpu: "{{ (ansible_processor_vcpus * 2) | int }}"
-    max_vms_ram: "{{ (_available_memory / manage_vms_ram_gb) | int }}"
+    max_vms_ram: "{{ (_available_memory | int / manage_vms_ram_gb) | int }}"
     max_vms_storage: "{{ ((storage_total_gb | int * (100 - manage_vms_host_storage_buffer_percent) / 100) / manage_vms_storage_gb) | int }}"
 
 - name: Get current VM count

--- a/deeep/core/roles/manage_vms/tasks/main.yml
+++ b/deeep/core/roles/manage_vms/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure running on VM
+- name: Ensure running on Device
   ansible.builtin.assert:
     that: ansible_virtualization_role == 'host'
 

--- a/deeep/core/roles/manage_vms/tasks/prune.yml
+++ b/deeep/core/roles/manage_vms/tasks/prune.yml
@@ -13,11 +13,6 @@
   register: lxd_vms
   changed_when: false
 
-- name: Determine limiting factor
-  ansible.builtin.set_fact:
-    current_vms: "{{ lxd_vms.stdout_lines | select('match', '^vm-.*') | list }}"
-    max_vms: "{{ [max_vms_cpu, max_vms_ram] | min }}"
-
 - name: Determine VMs to prune
   vars:
     _expected: "{{ _vms.get('json', {}).get('data', {}).get('expected', []) }}"

--- a/raw/setup-base.sh
+++ b/raw/setup-base.sh
@@ -10,14 +10,14 @@ backoff=5  # Starting backoff time in seconds
 max_backoff=$((5 * 60))  # 5 minutes in seconds
 attempt=1
 
-## install hab on local host
+## install hab on local host to be able to install ansible
 curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash
 sudo hab license accept
 sudo hab origin key download deeep-network
 
 while true; do
     echo "Attempt $attempt: Installing deeep-network/ansible..."
-    if sudo hab pkg install deeep-network/ansible --channel unstable; then
+    if sudo hab pkg install deeep-network/ansible; then
         echo "Successfully installed ansible package"
         break
     fi


### PR DESCRIPTION
### TL;DR
Fixed VM management and Habitat supervisor configuration issues while upgrading core collection to version 2.1.2.

### What changed?
- Fixed integer division in VM capacity calculation
- Updated Habitat supervisor service configuration to use virtualization role instead of playbook name
- Added explicit systemd service management for Habitat supervisor
- Removed unstable channel requirement for ansible package installation
- Improved VM pruning logic
- Fixed assertion message for VM host check

### How to test?
1. Run setup-base.sh on a new device
2. Verify Habitat supervisor starts correctly
3. Create and manage VMs to ensure capacity calculations work
4. Verify auto-deploy timer and services are running
5. Check VM pruning operates correctly

### Why make this change?
Several bugs were discovered in production:
- VM capacity calculations were failing due to float/integer division issues
- Habitat supervisor wasn't properly configured for different virtualization roles
- System services weren't being managed correctly
- The unstable channel requirement was causing unnecessary installation failures

These fixes improve system stability and reliability while making the setup process more robust.