### PR TITLE
feat: :sparkles: adds status command and bug fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "ci",
     "tests"
   ],
-  "inline-bookmarks.view.showVisibleFilesOnly": false
+  "inline-bookmarks.view.showVisibleFilesOnly": false,
+  "git.autofetch": true
 }

--- a/deeep/core/playbooks/guest.yml
+++ b/deeep/core/playbooks/guest.yml
@@ -52,16 +52,24 @@
       vars:
         service_cmd: start
         service_name: "{{ item }}"
+      when: services_to_load | length > 0
       ansible.builtin.include_role:
         name: deeep.core.service
       loop: "{{ services_to_load }}"
-      when: services_to_load | length > 0
 
     - name: Stop services
       vars:
         service_cmd: stop
         service_name: "{{ item }}"
+      when: services_to_unload | length > 0
       ansible.builtin.include_role:
         name: deeep.core.service
       loop: "{{ services_to_unload }}"
-      when: services_to_unload | length > 0
+
+    - name: Check statuses
+      when:
+        - required_services | length > 0
+        - services_to_load | length == 0
+      ansible.builtin.include_role:
+        name: deeep.core.service
+      loop: "{{ services_to_unload }}"

--- a/deeep/core/playbooks/setup.yml
+++ b/deeep/core/playbooks/setup.yml
@@ -90,7 +90,7 @@
       ansible.builtin.wait_for:
         path: /hab/sup/default/LOCK
         state: present
-        timeout: 30
+        timeout: 300
 
     - name: Load iLert Heartbeat
       block:

--- a/deeep/core/roles/service/tasks/commands/status.yml
+++ b/deeep/core/roles/service/tasks/commands/status.yml
@@ -1,0 +1,32 @@
+---
+- name: Check status for {{ service_name }}
+  become: true
+  become_user: root
+  block:
+    - name: Check if status script exists
+      ansible.builtin.stat:
+        path: /hab/svc/{{ service_name }}/config_install/status.sh
+      register: status_script
+
+    - name: Assert status script exists
+      ansible.builtin.assert:
+        that: status_script.stat.exists
+        fail_msg: "Status script not found for {{ service_name }}"
+
+    - name: Try packages status script
+      ansible.builtin.shell:
+        cmd: /hab/svc/{{ service_name }}/config_install/status.sh
+      args:
+        executable: /bin/bash
+      changed_when: false
+      register: _status
+  rescue:
+    - name: Fallback to hab status
+      ansible.builtin.command:
+        cmd: sudo hab svc status
+      changed_when: false
+      register: _status
+
+- name: Print status
+  ansible.builtin.debug:
+    msg: "{{ _status.stdout | regex_replace('\u001b\\[[0-9;]*[mK]', '') | regex_replace('\\n', ' ') | trim }}"


### PR DESCRIPTION
### TL;DR

Added service status checking capabilities and increased supervisor timeout for more reliable service management.

### What changed?

- Added new status checking functionality for services with a dedicated status.yml task
- Increased the supervisor LOCK wait timeout from 30 to 300 seconds
- Reordered service management conditions in guest.yml for better flow
- Added git autofetch setting in VS Code configuration
- Implemented status script checking with fallback to hab status command

### How to test?

1. Run a service deployment and verify the increased timeout allows proper supervisor initialization
2. Test service status checking:
   - With a service that has a status.sh script
   - With a service that falls back to hab status
3. Verify service management operations (start/stop) work as expected with the reordered conditions

### Why make this change?

The increased timeout provides more reliability during service initialization, while the new status checking capability offers better service health monitoring. The reordered conditions improve the logical flow of service management operations.